### PR TITLE
Fix startup banner version (v0.0.1 -> v0.0.3)

### DIFF
--- a/bin/melchat.js
+++ b/bin/melchat.js
@@ -75,7 +75,7 @@ server.listen(flags.port, () => {
   console.log(`
   ╔═══════════════════════════════════════════════════╗
   ║                                                   ║
-  ║   🤖 melchat v0.0.1                               ║
+  ║   🤖 melchat v0.0.3                               ║
   ║   100+ AI models in one interface                 ║
   ║                                                   ║
   ║   Running at: ${url.padEnd(31)}║


### PR DESCRIPTION
The CLI startup banner hard-coded `melchat v0.0.1` while package.json is at `0.0.3`, so `npx melchat` printed the wrong version. Same width, banner box stays aligned.